### PR TITLE
Make the subprocess call compatible with Ubuntu 16.04

### DIFF
--- a/dot2tex-filter.py
+++ b/dot2tex-filter.py
@@ -20,7 +20,7 @@ def dot2tex(key, value, format, meta):
                 scale = pair[1]
         graph = value[1]
         p = Popen(['dot2tex', '--figonly', '--autosize', '--codeonly'], stdout=PIPE, stdin=PIPE, stderr=PIPE)
-        response = p.communicate(input=bytes(graph, "utf-8"))
+        response = p.communicate(input=graph.encode("utf-8"))
         err = response[1].decode("utf-8")
         if len(err) != 0:
             raise ValueError(err)


### PR DESCRIPTION
On my machine, the `bytes()` method did not work properly. This workaround has helped.

Not 100% sure about the exact reason... Please feel free to discard this PR if I'm missing something essential.